### PR TITLE
feat(ui): add screens (4 files) and update main.dart routes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,14 @@
+// main.dart
+import 'package:flutter/material.dart';
+
+// Your existing auth UIs:
+import 'screens/login_screen.dart';
+import 'screens/register_screen.dart';
+
+// ===== Recording / Transcription deps =====
 import 'dart:ffi';
 import 'dart:io';
 import 'package:ffi/ffi.dart';
-import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:record/record.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -16,38 +23,59 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(title: const Text('Whisper Transcription')),
-        body: const TranscriptionWidget(),
-      ),
+      title: 'Quran Recitation Checker',
+      theme: ThemeData(primarySwatch: Colors.green),
+      // Start on Login
+      initialRoute: '/login',
+      routes: {
+        '/login': (_) => const LoginScreen(),
+        '/register': (_) => const RegisterScreen(),
+        '/recording': (_) => const RecordingScreen(),
+      },
     );
   }
 }
 
-// ignore: library_private_types_in_public_api
-class TranscriptionWidget extends StatefulWidget {
-  const TranscriptionWidget({super.key});
+/// Simple wrapper page that hosts the recorder/transcriber widget.
+class RecordingScreen extends StatelessWidget {
+  const RecordingScreen({super.key});
 
   @override
-  _TranscriptionWidgetState createState() => _TranscriptionWidgetState();
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Whisper Transcription')),
+      body: TranscriptionWidget(),
+    );
+  }
+}
+
+// =============== Transcription implementation ===============
+
+class TranscriptionWidget extends StatefulWidget {
+  const TranscriptionWidget({super.key});
+  @override
+  State<TranscriptionWidget> createState() => _TranscriptionWidgetState();
 }
 
 class _TranscriptionWidgetState extends State<TranscriptionWidget> {
   final record = AudioRecorder();
   String transcription = '';
   bool isRecording = false;
+
   DynamicLibrary? whisperLib;
-  late Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>) whisperTranscribe;
+  late Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+  whisperTranscribe;
 
   @override
   void initState() {
     super.initState();
-    // Load libwhisper.so
+    // Load libwhisper.so from jniLibs
     try {
       whisperLib = DynamicLibrary.open('libwhisper.so');
       whisperTranscribe = whisperLib!.lookupFunction<
           Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
-          Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)>('whisper_transcribe');
+          Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>,
+              Pointer<Utf8>)>('whisper_transcribe');
     } catch (e) {
       setState(() => transcription = 'Error loading libwhisper.so: $e');
     }
@@ -56,45 +84,48 @@ class _TranscriptionWidgetState extends State<TranscriptionWidget> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    copyAssetsToDocuments();
+    _copyModelToDocuments();
   }
 
-  // ignore: use_build_context_synchronously
-  Future<void> copyAssetsToDocuments() async {
+  Future<void> _copyModelToDocuments() async {
     try {
-      final directory = await getApplicationDocumentsDirectory();
-      final modelPath = '${directory.path}/ggml-tarteel-whisper-q4.bin';
+      final dir = await getApplicationDocumentsDirectory();
+      final modelPath = '${dir.path}/ggml-tarteel-whisper-q4.bin';
       if (!await File(modelPath).exists()) {
-        final data = await DefaultAssetBundle.of(context).load('assets/ggml-tarteel-whisper-q4.bin');
-        final bytes = data.buffer.asUint8List();
-        await File(modelPath).writeAsBytes(bytes);
+        final data = await DefaultAssetBundle.of(context)
+            .load('assets/ggml-tarteel-whisper-q4.bin');
+        await File(modelPath).writeAsBytes(
+          data.buffer.asUint8List(),
+          flush: true,
+        );
       }
     } catch (e) {
       setState(() => transcription = 'Error copying model: $e');
     }
   }
 
-  Future<String> getFilePath(String filename) async {
-    final directory = await getApplicationDocumentsDirectory();
-    return '${directory.path}/$filename';
+  Future<String> _pathInDocs(String filename) async {
+    final dir = await getApplicationDocumentsDirectory();
+    return '${dir.path}/$filename';
   }
 
-  Future<void> startRecording() async {
+  Future<void> _startRecording() async {
     try {
-      if (await Permission.microphone.request().isGranted) {
-        setState(() => isRecording = true);
-        final wavPath = await getFilePath('recording.wav');
-        await record.start(
-          const RecordConfig(
-            encoder: AudioEncoder.wav,
-            sampleRate: 16000,
-            numChannels: 1,
-          ),
-          path: wavPath,
-        );
-      } else {
+      final mic = await Permission.microphone.request();
+      if (!mic.isGranted) {
         setState(() => transcription = 'Microphone permission not granted');
+        return;
       }
+      setState(() => isRecording = true);
+      final wavPath = await _pathInDocs('recording.wav');
+      await record.start(
+        const RecordConfig(
+          encoder: AudioEncoder.wav,
+          sampleRate: 16000,
+          numChannels: 1,
+        ),
+        path: wavPath,
+      );
     } catch (e) {
       setState(() {
         isRecording = false;
@@ -103,28 +134,31 @@ class _TranscriptionWidgetState extends State<TranscriptionWidget> {
     }
   }
 
-  Future<void> stopRecording() async {
+  Future<void> _stopRecording() async {
     try {
       setState(() => isRecording = false);
       final wavPath = await record.stop();
-      if (wavPath != null) {
-        final modelPath = await getFilePath('ggml-tarteel-whisper-q4.bin');
-        final modelPathPtr = modelPath.toNativeUtf8();
-        final wavPathPtr = wavPath.toNativeUtf8();
-        final langPtr = 'ar'.toNativeUtf8();
-        try {
-          final resultPtr = whisperTranscribe(modelPathPtr, wavPathPtr, langPtr);
-          final result = resultPtr.toDartString();
-          setState(() => transcription = result.isEmpty ? 'No transcription generated' : result);
-          malloc.free(resultPtr);
-        } catch (e) {
-          setState(() => transcription = 'Error during transcription: $e');
-        }
-        malloc.free(modelPathPtr);
-        malloc.free(wavPathPtr);
-        malloc.free(langPtr);
-      } else {
+      if (wavPath == null) {
         setState(() => transcription = 'No recording file generated');
+        return;
+      }
+
+      final modelPath = await _pathInDocs('ggml-tarteel-whisper-q4.bin');
+      final modelPtr = modelPath.toNativeUtf8();
+      final wavPtr = wavPath.toNativeUtf8();
+      final langPtr = 'ar'.toNativeUtf8();
+
+      try {
+        final resPtr = whisperTranscribe(modelPtr, wavPtr, langPtr);
+        final res = resPtr.toDartString();
+        setState(() => transcription = res.isEmpty ? 'No transcription generated' : res);
+        malloc.free(resPtr); // Only valid if the native side allocated with malloc
+      } catch (e) {
+        setState(() => transcription = 'Error during transcription: $e');
+      } finally {
+        malloc.free(modelPtr);
+        malloc.free(wavPtr);
+        malloc.free(langPtr);
       }
     } catch (e) {
       setState(() => transcription = 'Error stopping recording: $e');
@@ -134,16 +168,217 @@ class _TranscriptionWidgetState extends State<TranscriptionWidget> {
   @override
   Widget build(BuildContext context) {
     return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Text(transcription.isEmpty ? 'No transcription yet' : transcription),
-          ElevatedButton(
-            onPressed: isRecording ? stopRecording : startRecording,
-            child: Text(isRecording ? 'Stop Recording' : 'Start Recording'),
-          ),
-        ],
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(transcription.isEmpty ? 'No transcription yet' : transcription),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: isRecording ? _stopRecording : _startRecording,
+              child: Text(isRecording ? 'Stop Recording' : 'Start Recording'),
+            ),
+          ],
+        ),
       ),
     );
   }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+//
+// import 'dart:ffi';
+// import 'dart:io';
+// import 'package:ffi/ffi.dart';
+// import 'package:flutter/material.dart';
+// import 'package:path_provider/path_provider.dart';
+// import 'package:record/record.dart';
+// import 'package:permission_handler/permission_handler.dart';
+//
+// void main() {
+//   runApp(const MyApp());
+// }
+//
+// class MyApp extends StatelessWidget {
+//   const MyApp({super.key});
+//
+//   @override
+//   Widget build(BuildContext context) {
+//     return MaterialApp(
+//       home: Scaffold(
+//         appBar: AppBar(title: const Text('Whisper Transcription')),
+//         body: const TranscriptionWidget(),
+//       ),
+//     );
+//   }
+// }
+//
+// // ignore: library_private_types_in_public_api
+// class TranscriptionWidget extends StatefulWidget {
+//   const TranscriptionWidget({super.key});
+//
+//   @override
+//   _TranscriptionWidgetState createState() => _TranscriptionWidgetState();
+// }
+//
+// class _TranscriptionWidgetState extends State<TranscriptionWidget> {
+//   final record = AudioRecorder();
+//   String transcription = '';
+//   bool isRecording = false;
+//   DynamicLibrary? whisperLib;
+//   late Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>) whisperTranscribe;
+//
+//   @override
+//   void initState() {
+//     super.initState();
+//     // Load libwhisper.so
+//     try {
+//       whisperLib = DynamicLibrary.open('libwhisper.so');
+//       whisperTranscribe = whisperLib!.lookupFunction<
+//           Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+//           Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)>('whisper_transcribe');
+//     } catch (e) {
+//       setState(() => transcription = 'Error loading libwhisper.so: $e');
+//     }
+//   }
+//
+//   @override
+//   void didChangeDependencies() {
+//     super.didChangeDependencies();
+//     copyAssetsToDocuments();
+//   }
+//
+//   // ignore: use_build_context_synchronously
+//   Future<void> copyAssetsToDocuments() async {
+//     try {
+//       final directory = await getApplicationDocumentsDirectory();
+//       final modelPath = '${directory.path}/ggml-tarteel-whisper-q4.bin';
+//       if (!await File(modelPath).exists()) {
+//         final data = await DefaultAssetBundle.of(context).load('assets/ggml-tarteel-whisper-q4.bin');
+//         final bytes = data.buffer.asUint8List();
+//         await File(modelPath).writeAsBytes(bytes);
+//       }
+//     } catch (e) {
+//       setState(() => transcription = 'Error copying model: $e');
+//     }
+//   }
+//
+//   Future<String> getFilePath(String filename) async {
+//     final directory = await getApplicationDocumentsDirectory();
+//     return '${directory.path}/$filename';
+//   }
+//
+//   Future<void> startRecording() async {
+//     try {
+//       if (await Permission.microphone.request().isGranted) {
+//         setState(() => isRecording = true);
+//         final wavPath = await getFilePath('recording.wav');
+//         await record.start(
+//           const RecordConfig(
+//             encoder: AudioEncoder.wav,
+//             sampleRate: 16000,
+//             numChannels: 1,
+//           ),
+//           path: wavPath,
+//         );
+//       } else {
+//         setState(() => transcription = 'Microphone permission not granted');
+//       }
+//     } catch (e) {
+//       setState(() {
+//         isRecording = false;
+//         transcription = 'Error starting recording: $e';
+//       });
+//     }
+//   }
+//
+//   Future<void> stopRecording() async {
+//     try {
+//       setState(() => isRecording = false);
+//       final wavPath = await record.stop();
+//       if (wavPath != null) {
+//         final modelPath = await getFilePath('ggml-tarteel-whisper-q4.bin');
+//         final modelPathPtr = modelPath.toNativeUtf8();
+//         final wavPathPtr = wavPath.toNativeUtf8();
+//         final langPtr = 'ar'.toNativeUtf8();
+//         try {
+//           final resultPtr = whisperTranscribe(modelPathPtr, wavPathPtr, langPtr);
+//           final result = resultPtr.toDartString();
+//           setState(() => transcription = result.isEmpty ? 'No transcription generated' : result);
+//           malloc.free(resultPtr);
+//         } catch (e) {
+//           setState(() => transcription = 'Error during transcription: $e');
+//         }
+//         malloc.free(modelPathPtr);
+//         malloc.free(wavPathPtr);
+//         malloc.free(langPtr);
+//       } else {
+//         setState(() => transcription = 'No recording file generated');
+//       }
+//     } catch (e) {
+//       setState(() => transcription = 'Error stopping recording: $e');
+//     }
+//   }
+//
+//   @override
+//   Widget build(BuildContext context) {
+//     return Center(
+//       child: Column(
+//         mainAxisAlignment: MainAxisAlignment.center,
+//         children: [
+//           Text(transcription.isEmpty ? 'No transcription yet' : transcription),
+//           ElevatedButton(
+//             onPressed: isRecording ? stopRecording : startRecording,
+//             child: Text(isRecording ? 'Stop Recording' : 'Start Recording'),
+//           ),
+//         ],
+//       ),
+//     );
+//   }
+// }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'register_screen.dart';
+import 'recording_screen.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  final String hardcodedEmail = "test@example.com";
+  final String hardcodedPassword = "123456";
+
+  void _login() {
+    if (_emailController.text == hardcodedEmail &&
+        _passwordController.text == hardcodedPassword) {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (_) => const RecordingScreen()),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text("Invalid email or password")),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF2E7D32), Color(0xFF66BB6A)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Center(
+          child: SingleChildScrollView(
+            child: Container(
+              margin: const EdgeInsets.symmetric(horizontal: 20),
+              padding: const EdgeInsets.all(24),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: BorderRadius.circular(20),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black26,
+                    blurRadius: 12,
+                    offset: const Offset(0, 6),
+                  ),
+                ],
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(
+                    Icons.mosque,
+                    size: 70,
+                    color: Colors.green,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    "Quranic Recitation ",
+                    style: GoogleFonts.poppins(
+                      fontSize: 26,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.green[800],
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    "Login to continue",
+                    style: GoogleFonts.poppins(
+                      fontSize: 14,
+                      color: Colors.grey[600],
+                    ),
+                  ),
+                  const SizedBox(height: 30),
+
+                  // Email Field
+                  TextField(
+                    controller: _emailController,
+                    decoration: InputDecoration(
+                      prefixIcon: const Icon(Icons.email_outlined),
+                      labelText: "Email",
+                      labelStyle: GoogleFonts.poppins(),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+
+                  // Password Field
+                  TextField(
+                    controller: _passwordController,
+                    obscureText: true,
+                    decoration: InputDecoration(
+                      prefixIcon: const Icon(Icons.lock_outline),
+                      labelText: "Password",
+                      labelStyle: GoogleFonts.poppins(),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 25),
+
+                  // Login Button
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: _login,
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        backgroundColor: Colors.green[700],
+                      ),
+                      child: Text(
+                        "Login",
+                        style: GoogleFonts.poppins(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ),
+                  ),
+
+                  const SizedBox(height: 20),
+
+                  // Register Navigation
+                  TextButton(
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (_) => const RegisterScreen()),
+                      );
+                    },
+                    child: Text(
+                      "Don’t have an account? Register",
+                      style: GoogleFonts.poppins(
+                        color: Colors.green[800],
+                        fontSize: 14,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/recording_screen.dart
+++ b/lib/screens/recording_screen.dart
@@ -1,0 +1,278 @@
+import 'dart:ffi';
+import 'dart:io';
+import 'package:ffi/ffi.dart';
+import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:record/record.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import 'result_screen.dart';
+
+class RecordingScreen extends StatefulWidget {
+  const RecordingScreen({super.key});
+
+  @override
+  State<RecordingScreen> createState() => _RecordingScreenState();
+}
+
+class _RecordingScreenState extends State<RecordingScreen>
+    with SingleTickerProviderStateMixin {
+  final record = AudioRecorder();
+  bool isRecording = false;
+  String transcription = '';
+
+  DynamicLibrary? whisperLib;
+  late Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
+  whisperTranscribe;
+
+  late AnimationController _pulseController;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulseController =
+    AnimationController(vsync: this, duration: const Duration(seconds: 1))
+      ..repeat(reverse: true);
+
+    try {
+      whisperLib = DynamicLibrary.open('libwhisper.so');
+      whisperTranscribe = whisperLib!.lookupFunction<
+          Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+          Pointer<Utf8> Function(Pointer<Utf8>, Pointer<Utf8>,
+              Pointer<Utf8>)>('whisper_transcribe');
+    } catch (e) {
+      setState(() {
+        transcription = 'Error loading libwhisper.so: $e';
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    copyAssetsToDocuments();
+  }
+
+  Future<void> copyAssetsToDocuments() async {
+    try {
+      final directory = await getApplicationDocumentsDirectory();
+      final modelPath = '${directory.path}/ggml-tarteel-whisper-q4.bin';
+      if (!await File(modelPath).exists()) {
+        final data = await DefaultAssetBundle.of(context)
+            .load('assets/ggml-tarteel-whisper-q4.bin');
+        final bytes = data.buffer.asUint8List();
+        await File(modelPath).writeAsBytes(bytes);
+      }
+    } catch (e) {
+      setState(() {
+        transcription = 'Error copying model: $e';
+      });
+    }
+  }
+
+  Future<String> getFilePath(String filename) async {
+    final directory = await getApplicationDocumentsDirectory();
+    return '${directory.path}/$filename';
+  }
+
+  Future<void> startRecording() async {
+    try {
+      if (await Permission.microphone.request().isGranted) {
+        setState(() => isRecording = true);
+        final wavPath = await getFilePath('recording.wav');
+        await record.start(
+          const RecordConfig(
+            encoder: AudioEncoder.wav,
+            sampleRate: 16000,
+            numChannels: 1,
+          ),
+          path: wavPath,
+        );
+      } else {
+        setState(() {
+          transcription = 'Microphone permission not granted';
+        });
+      }
+    } catch (e) {
+      setState(() {
+        isRecording = false;
+        transcription = 'Error starting recording: $e';
+      });
+    }
+  }
+
+  Future<void> stopRecording() async {
+    try {
+      setState(() => isRecording = false);
+      final wavPath = await record.stop();
+      if (wavPath != null) {
+        final modelPath = await getFilePath('ggml-tarteel-whisper-q4.bin');
+        final modelPathPtr = modelPath.toNativeUtf8();
+        final wavPathPtr = wavPath.toNativeUtf8();
+        final langPtr = 'ar'.toNativeUtf8();
+        try {
+          final resultPtr =
+          whisperTranscribe(modelPathPtr, wavPathPtr, langPtr);
+          final result = resultPtr.toDartString();
+          malloc.free(resultPtr);
+
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => ResultScreen(
+                result: result.isEmpty ? 'No transcription generated' : result,
+              ),
+            ),
+          );
+        } catch (e) {
+          setState(() {
+            transcription = 'Error during transcription: $e';
+          });
+        }
+        malloc.free(modelPathPtr);
+        malloc.free(wavPathPtr);
+        malloc.free(langPtr);
+      } else {
+        setState(() {
+          transcription = 'No recording file generated';
+        });
+      }
+    } catch (e) {
+      setState(() {
+        transcription = 'Error stopping recording: $e';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF0f2027), Color(0xFF203a43), Color(0xFF2c5364)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              children: [
+                const Text(
+                  "🎙️ Voice Recorder",
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 26,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 40),
+                Expanded(
+                  child: Center(
+                    child: Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        if (isRecording)
+                          ScaleTransition(
+                            scale: Tween(begin: 1.0, end: 1.3)
+                                .animate(CurvedAnimation(
+                              parent: _pulseController,
+                              curve: Curves.easeInOut,
+                            )),
+                            child: Container(
+                              width: 180,
+                              height: 180,
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: Colors.redAccent.withOpacity(0.3),
+                                boxShadow: [
+                                  BoxShadow(
+                                    color: Colors.redAccent.withOpacity(0.6),
+                                    blurRadius: 40,
+                                    spreadRadius: 20,
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        Icon(
+                          isRecording ? Icons.mic : Icons.mic_none,
+                          size: 120,
+                          color: isRecording ? Colors.redAccent : Colors.white70,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Container(
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    color: Colors.white.withOpacity(0.05),
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: Text(
+                    transcription.isEmpty
+                        ? "Tap the mic to start speaking..."
+                        : transcription,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(
+                      color: Colors.white70,
+                      fontSize: 16,
+                      fontStyle: FontStyle.italic,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 40),
+                ElevatedButton.icon(
+                  onPressed: isRecording ? stopRecording : startRecording,
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 45, vertical: 20),
+                    backgroundColor:
+                    isRecording ? Colors.redAccent : Colors.deepPurple,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(35),
+                    ),
+                    elevation: 12,
+                    shadowColor: Colors.black54,
+                  ),
+                  icon: Icon(
+                    isRecording ? Icons.stop : Icons.mic,
+                    color: Colors.white,
+                    size: 28,
+                  ),
+                  label: Text(
+                    isRecording ? "Stop Recording" : "Start Recording",
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 25),
+                if (!isRecording && transcription.isNotEmpty)
+                  const Text(
+                    "Tap mic again to re-record",
+                    style: TextStyle(
+                      color: Colors.white54,
+                      fontSize: 14,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class RegisterScreen extends StatefulWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  State<RegisterScreen> createState() => _RegisterScreenState();
+}
+
+class _RegisterScreenState extends State<RegisterScreen> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  void _register() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text("Registered with ${_emailController.text}")),
+    );
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF4A148C), Color(0xFF7B1FA2), Color(0xFF9C27B0)], // purple shades
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Center(
+          child: SingleChildScrollView(
+            child: Container(
+              margin: const EdgeInsets.symmetric(horizontal: 20),
+              padding: const EdgeInsets.all(24),
+              decoration: BoxDecoration(
+                color: Colors.white.withOpacity(0.95),
+                borderRadius: BorderRadius.circular(22),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black26,
+                    blurRadius: 15,
+                    offset: const Offset(0, 6),
+                  ),
+                ],
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(
+                    Icons.person_add_alt_1, // different register icon
+                    size: 70,
+                    color: Color(0xFF6A1B9A),
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    "Join Us",
+                    style: GoogleFonts.poppins(
+                      fontSize: 28,
+                      fontWeight: FontWeight.bold,
+                      color: const Color(0xFF4A148C),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    "Create your account",
+                    style: GoogleFonts.poppins(
+                      fontSize: 15,
+                      color: Colors.grey[700],
+                    ),
+                  ),
+                  const SizedBox(height: 30),
+
+                  // Email Field
+                  TextField(
+                    controller: _emailController,
+                    decoration: InputDecoration(
+                      prefixIcon: const Icon(Icons.email_outlined),
+                      labelText: "Email",
+                      labelStyle: GoogleFonts.poppins(),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(14),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+
+                  // Password Field
+                  TextField(
+                    controller: _passwordController,
+                    obscureText: true,
+                    decoration: InputDecoration(
+                      prefixIcon: const Icon(Icons.lock_outline),
+                      labelText: "Password",
+                      labelStyle: GoogleFonts.poppins(),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(14),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 25),
+
+                  // Register Button
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: _register,
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 15),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(14),
+                        ),
+                        backgroundColor: const Color(0xFF6A1B9A),
+                      ),
+                      child: Text(
+                        "Register",
+                        style: GoogleFonts.poppins(
+                          fontSize: 17,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ),
+                  ),
+
+                  const SizedBox(height: 15),
+
+                  // Back to Login
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: Text(
+                      "Already have an account? Login",
+                      style: GoogleFonts.poppins(
+                        color: const Color(0xFF4A148C),
+                        fontSize: 14,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/result_screen.dart
+++ b/lib/screens/result_screen.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class ResultScreen extends StatelessWidget {
+  final String result;
+  const ResultScreen({super.key, required this.result});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Color(0xFF0f2027),
+              Color(0xFF203a43),
+              Color(0xFF2c5364),
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(20.0),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 600),
+              curve: Curves.easeOut,
+              padding: const EdgeInsets.all(28),
+              decoration: BoxDecoration(
+                color: Colors.white.withOpacity(0.95),
+                borderRadius: BorderRadius.circular(25),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.blueAccent.withOpacity(0.3),
+                    blurRadius: 25,
+                    spreadRadius: 5,
+                    offset: const Offset(0, 10),
+                  ),
+                ],
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(18),
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      gradient: const LinearGradient(
+                        colors: [Color(0xFF42A5F5), Color(0xFF1976D2)],
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.blue.withOpacity(0.4),
+                          blurRadius: 20,
+                          spreadRadius: 4,
+                        ),
+                      ],
+                    ),
+                    child: const Icon(
+                      Icons.check_circle_outline,
+                      size: 70,
+                      color: Colors.white,
+                    ),
+                  ),
+                  const SizedBox(height: 25),
+                  Text(
+                    "Transcription Result",
+                    style: GoogleFonts.poppins(
+                      fontSize: 28,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.blueGrey[900],
+                    ),
+                  ),
+                  const SizedBox(height: 18),
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: Colors.blueGrey.withOpacity(0.05),
+                      borderRadius: BorderRadius.circular(15),
+                    ),
+                    child: Text(
+                      result.isEmpty ? "No result available" : result,
+                      style: GoogleFonts.poppins(
+                        fontSize: 18,
+                        color: Colors.black87,
+                        height: 1.6,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  const SizedBox(height: 30),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: () => Navigator.pop(context),
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        backgroundColor: const Color(0xFF1976D2),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(15),
+                        ),
+                        elevation: 10,
+                        shadowColor: Colors.blueAccent,
+                      ),
+                      child: Text(
+                        "⬅ Back",
+                        style: GoogleFonts.poppins(
+                          fontSize: 17,
+                          fontWeight: FontWeight.w600,
+                          color: Colors.white,
+                        ),
+                      ),
+                    ),
+                  )
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Adds login/register/recording/result screens and wires routes in main.dart.
App opens on Login, then flows to Recording, then Result.

## Changes
- new: lib/screens/login_screen.dart
- new: lib/screens/register_screen.dart
- new: lib/screens/recording_screen.dart
- new: lib/screens/result_screen.dart
- update: lib/main.dart (routes + initial page)

## How to test
1) flutter pub get
2) flutter run
3) Verify: Login screen shows → navigate to Register (optional) → proceed to Recording → see Result screen.

## Notes
- No backend wired yet.
- No large assets added.
